### PR TITLE
fix: 'Protocol error (Runtime.callFunctionOn): Target closed.' when sending files larger than 80MB

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -596,6 +596,18 @@ class Client extends EventEmitter {
             );
         }
 
+        const isBigFile = internalOptions.attachment.data.length > (1024 * 1024 * 79);
+
+        if (isBigFile) {
+            const middle = internalOptions.attachment.data.length / 2;
+            await this.pupPage.evaluate(async (chatId, chunk) => {
+                if (chunk) {
+                    window.Store[`mediaChunk_${chatId}`] = chunk;
+                }
+            }, chatId, internalOptions.attachment.data.substring(0, middle));
+            internalOptions.attachment.data = internalOptions.attachment.data.substring(middle);
+        }
+
         const newMessage = await this.pupPage.evaluate(async (chatId, message, options, sendSeen) => {
             const chatWid = window.Store.WidFactory.createWid(chatId);
             const chat = await window.Store.Chat.find(chatWid);
@@ -603,6 +615,11 @@ class Client extends EventEmitter {
 
             if (sendSeen) {
                 window.WWebJS.sendSeen(chatId);
+            }
+
+            if(options.attachment.data && window.Store[`mediaChunk_${chatId}`]) {
+                options.attachment.data = window.Store[`mediaChunk_${chatId}`] + options.attachment.data;
+                delete window.Store[`mediaChunk_${chatId}`];
             }
 
             const msg = await window.WWebJS.sendMessage(chat, message, options, sendSeen);


### PR DESCRIPTION
```
ProtocolError: Protocol error (Runtime.callFunctionOn): Target closed.
    at /home/user/Projects/Bot/node_modules/puppeteer/src/common/Connection.ts:304:16
    at new Promise (<anonymous>)
    at CDPSession.send (/home/user/Projects/Bot/node_modules/puppeteer/src/common/Connection.ts:300:12)
    at ExecutionContext._evaluateInternal (/home/user/Projects/Bot/node_modules/puppeteer/src/common/ExecutionContext.ts:254:44)
    at ExecutionContext.evaluate (/home/user/Projects/Bot/node_modules/puppeteer/src/common/ExecutionContext.ts:140:23)
    at DOMWorld.evaluate (/home/user/Projects/Bot/node_modules/puppeteer/src/common/DOMWorld.ts:174:20)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```